### PR TITLE
refactor(cli): simplify init and edit templates with realistic examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,12 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.out
           flags: unittests
-          name: ${{ matrix.os }}-go${{ matrix.go-version }}
+          name: go${{ matrix.go-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build:

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -397,49 +397,37 @@ func Init() error {
 # Dirvana configuration file
 # Documentation: https://github.com/NikitaCOEUR/dirvana
 
-# Shell aliases - Simple format (auto-detects completion)
+# Shell aliases
 aliases:
-  ll: ls -lah
-  gs: git status
-  gd: git diff
-  k: kubectl
+  # Simple string aliases (auto-detects completion)
+  # g: git
 
   # Advanced format with completion control
-  gp:
-    command: git push
-    completion: git  # Inherit git completion
+  # tf:
+  #  command: task terraform --
+  #  completion: terraform  # Inherits terraform's auto-completion
 
-  # Custom wrapper with inherited completion
-  mykubectl:
-    command: /usr/local/bin/kubectl-wrapper.sh
-    completion: kubectl
-
-  # Disable completion
-  hello:
-    command: echo "Hello World"
-    completion: false
-
-  # Custom completion (advanced)
-  deploy:
-    command: ./scripts/deploy.sh
-    completion:
-      bash: complete -W "dev staging prod" deploy
-      zsh: compdef '_arguments "1: :(dev staging prod)"' deploy
-
-# Shell functions
+# Shell functions - reusable command sequences with parameters
 functions:
-  mkcd: |
-    mkdir -p "$1" && cd "$1"
-  greet: |
-    echo "Hello, $1!"
+  # Simple greeting function
+  # greet: |
+  #   echo "Hello, $1!"
 
 # Environment variables
 env:
-  PROJECT_NAME: myproject
-  LOG_LEVEL: info
+  # Static values
+  # PROJECT_NAME: myproject
 
-# Set to true to ignore parent configs
-local_only: false
+  # Dynamic values from shell commands (evaluated on load)
+  # CURRENT_USER:
+  #	  sh: whoami
+
+# Configuration flags
+# Set to true to ignore parent configs (only use this directory's config)
+# local_only: false
+
+# Set to true to ignore global config (~/.config/dirvana/global.yml)
+# ignore_global: false
 `
 
 	if err := os.WriteFile(configPath, []byte(sampleConfig), 0644); err != nil {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -30,27 +30,39 @@ func Edit() error {
 	if configPath == "" {
 		configPath = filepath.Join(currentDir, ".dirvana.yml")
 		defaultContent := `# yaml-language-server: $schema=https://raw.githubusercontent.com/NikitaCOEUR/dirvana/main/schema/dirvana.schema.json
-# Dirvana configuration
-# See: https://github.com/NikitaCOEUR/dirvana
+# Dirvana configuration file
+# Documentation: https://github.com/NikitaCOEUR/dirvana
 
 # Shell aliases
 aliases:
-  # ll: ls -la
+  # Simple string aliases (auto-detects completion)
+  # g: git
 
-# Shell functions
+  # Advanced format with completion control
+  # tf:
+  #  command: task terraform --
+  #  completion: terraform  # Inherits terraform's auto-completion
+
+# Shell functions - reusable command sequences with parameters
 functions:
-  # greet: echo "Hello, $1"
+  # Simple greeting function
+  # greet: |
+  #   echo "Hello, $1!"
 
 # Environment variables
 env:
-  # PROJECT_ROOT: .
-  # DYNAMIC_VAR:
-  #   sh: date +%s
+  # Static values
+  # PROJECT_NAME: myproject
 
-# Prevent merging with parent configs
+  # Dynamic values from shell commands (evaluated on load)
+  # CURRENT_USER:
+  #	  sh: whoami
+
+# Configuration flags
+# Set to true to ignore parent configs (only use this directory's config)
 # local_only: false
 
-# Ignore global config
+# Set to true to ignore global config (~/.config/dirvana/global.yml)
 # ignore_global: false
 `
 		if err := os.WriteFile(configPath, []byte(defaultContent), 0644); err != nil {


### PR DESCRIPTION
- Replace overly complex examples with simple, commented template
- Remove references to non-existent commands (kubectl wrapper, deploy scripts)
- Align both init and edit to generate identical templates
- Use realistic examples: git aliases, terraform via task
- Add better documentation for completion, functions, and dynamic env vars
- All examples are commented out to serve as true templates