### PR TITLE
fix(completion): restore fish completion for commands fish does not know

### DIFF
--- a/internal/shell/generators_test.go
+++ b/internal/shell/generators_test.go
@@ -408,7 +408,7 @@ func TestFishCodeGenerator_GenerateCompletionFunction_FunctionFallback(t *testin
 	assert.Contains(t, script, "complete -c myfunc -a '(__dirvana_complete_fish)'")
 }
 
-func TestFishCodeGenerator_GenerateCompletionFunction_DefersToFishOnFirstLevel(t *testing.T) {
+func TestFishCodeGenerator_GenerateCompletionFunction_DefersToFishWhenCovered(t *testing.T) {
 	gen := &FishCodeGenerator{}
 
 	aliasCommands := map[string]string{"k": "kubectl"}
@@ -419,11 +419,19 @@ func TestFishCodeGenerator_GenerateCompletionFunction_DefersToFishOnFirstLevel(t
 	assert.Contains(t, script, "__dirvana_complete_fish kubectl")
 	assert.Contains(t, script, "underlying_cmd")
 
-	// Fish covers the first level on its own through `complete -w`, and
-	// asking dirvana costs a fork on every keypress. The function must
-	// therefore bail out while the line holds no more than the command
-	// itself, and only for aliases that do wrap a command.
-	assert.Contains(t, script, `if test -n "$underlying_cmd"; and test (count $cmd) -le 1`)
+	// Asking dirvana costs a fork on every keypress, so it must stand down
+	// whenever `complete -w` already forwards to real completions - and only
+	// then, since a command fish knows nothing about gets no completion at
+	// all without dirvana.
+	assert.Contains(t, script, "function __dirvana_fish_covers")
+	assert.Contains(t, script, `if test -n "$underlying_cmd"; and __dirvana_fish_covers $underlying_cmd`)
+
+	// The probe must ask for long flags: file names never match them, so a
+	// non-empty answer proves the command has completions of its own
+	assert.Contains(t, script, `complete -C"$cmd --"`)
+
+	// And it must be answered once per command, not on every keypress
+	assert.Contains(t, script, "set -g $varname")
 }
 
 func TestGenerateHookCode_Fish(t *testing.T) {

--- a/internal/shell/templates/completion/fish_function.tmpl
+++ b/internal/shell/templates/completion/fish_function.tmpl
@@ -1,6 +1,32 @@
 #!/usr/bin/env fish
 # Fish completions
 
+# __dirvana_fish_covers reports whether fish can already complete a
+# command on its own, so dirvana can stay out of the way.
+#
+# Fish ships completions for over a thousand commands, and `complete -w`
+# forwards every level to them, dynamic values included. Where no such
+# completions exist, fish offers plain file names and dirvana is the only
+# thing that can help - from the very first word.
+#
+# The probe asks for long-flag completions: file names never match `--`,
+# so anything coming back proves real completions exist. The answer is
+# kept for the session, since it cannot change under a running shell.
+function __dirvana_fish_covers -a cmd
+  set -l key (string replace -a -r '[^a-zA-Z0-9_]' _ -- $cmd)
+  set -l varname __dirvana_fish_covers_$key
+
+  if not set -q $varname
+    if test (count (complete -C"$cmd --")) -gt 0
+      set -g $varname 1
+    else
+      set -g $varname 0
+    end
+  end
+
+  test $$varname -eq 1
+end
+
 function __dirvana_complete_fish
   # Get underlying command name (passed as argument)
   set -l underlying_cmd ""
@@ -8,25 +34,15 @@ function __dirvana_complete_fish
     set underlying_cmd $argv[1]
   end
 
-  # Get the current command line (all tokens except current word being completed)
-  set -l cmd (commandline -opc)
-
   # Fish evaluates every completion provider on each keypress, and asking
-  # dirvana costs a fork plus a run of the underlying tool - around 150ms.
-  # It is only worth paying where fish comes up short.
-  #
-  # When the alias wraps a command, `complete -w` already covers the first
-  # level: fish reads the command's own completion file, or derives one
-  # from its --help. What it cannot derive is anything deeper - subcommand
-  # arguments, resource names, dynamic values - which is exactly what the
-  # __complete protocol provides. So dirvana only steps in past the first
-  # token.
-  #
-  # Aliases with no underlying command have no `complete -w` to lean on,
-  # so dirvana answers from the start.
-  if test -n "$underlying_cmd"; and test (count $cmd) -le 1
+  # dirvana costs a fork plus a run of the underlying tool - around 200ms.
+  # Skip it entirely when `complete -w` already has the command covered.
+  if test -n "$underlying_cmd"; and __dirvana_fish_covers $underlying_cmd
     return 0
   end
+
+  # Get the current command line (all tokens except current word being completed)
+  set -l cmd (commandline -opc)
 
   # Get the current token being completed
   set -l current_token (commandline -ct)


### PR DESCRIPTION
## Regression introduced in v0.9.0

v0.9.0 made dirvana stand down on the first token in fish, assuming `complete -w` always covers that level. It does not. For any command fish ships no completions for — in-house tools, Go binaries installed through aqua/asdf, anything not packaged — the alias lost completion entirely:

```
cobratool (Cobra protocol, no fish completion file)
  before v0.9.0 : alpha, beta          (dirvana answered)
  v0.9.0        : 0 suggestions
```

## What I got wrong

Two measurement mistakes led to that premise.

**Looking for `<cmd>.fish` in `$fish_complete_path` finds nothing**, because the system directory holding fish's 1000+ bundled completion files is not on that variable. kubectl looked uncovered while `/usr/share/fish/completions/kubectl.fish` exists — a one-liner that sources `kubectl completion fish`.

**`kubectl get <TAB>` returning nothing was not fish falling short.** It was kubectl needing a reachable cluster. Through an alias, fish forwards every level correctly:

| | direct | through a `-w` alias |
|---|---|---|
| `kubectl <TAB>` | 48 | 48 |
| `kubectl config <TAB>` | 15 | 15 |

## The actual rule

The split is not by depth but by whether fish knows the command at all:

- **fish knows it** → `complete -w` forwards everything, dynamic values included. Dirvana is pure overhead.
- **fish does not** → it offers plain file names. Dirvana is the only source, from the first word.

The completion function now asks fish directly, once per command and per session: file names never match a `--` prefix, so any answer proves real completions exist.

```
kubectl 30    git 20    helm 20    gh 2    cobratool 0
```

## Measurements

With kubectl, after the probe is memoised:

| | latency | suggestions |
|---|---|---|
| fish alone (`kubectl <TAB>`) | 415-426 ms | 48 |
| plain `-w` alias, no dirvana at all | 523-539 ms | 48 |
| dirvana alias (this PR) | 489-508 ms | 48 |

No overhead left against a bare wrapped alias, and a command fish does not know completes at every level again.

## Test plan

- [x] `go test -race ./...`, `golangci-lint run` (0 issues)
- [x] `fish -n` on the template
- [x] Behaviour verified in a real fish 4.7 shell, both cases: a fish-covered command (kubectl) and a Cobra tool fish knows nothing about
- [ ] Follow-up: fish has no completion coverage in the integration suite at all — the table only holds bash and zsh, and `test_fish_completion.sh` is never called

🤖 Generated with [Claude Code](https://claude.com/claude-code)
