### PR TITLE
test(completion): cover fish in the integration suite

### DIFF
--- a/.github/workflows/completion-tests.yml
+++ b/.github/workflows/completion-tests.yml
@@ -29,3 +29,25 @@ jobs:
         run: task test-completion
         env:
           TEST_SHELL: bash
+
+  completion-fish:
+    name: Fish completion suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Set up aqua
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.55.1
+
+      - name: Run fish completion tests in Docker
+        run: task test-completion
+        env:
+          TEST_SHELL: fish

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -176,7 +176,7 @@ tasks:
         -f tests/completion/Dockerfile .
 
   test-completion:
-    desc: Test completion system in Docker (TEST_SHELL=bash|zsh)
+    desc: Test completion system in Docker (TEST_SHELL=bash|zsh|fish)
     deps: [build, build-completion-image]
     vars:
       SHELL_TYPE: '{{.TEST_SHELL | default "bash"}}'

--- a/tests/completion/Dockerfile
+++ b/tests/completion/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     bash-completion \
     zsh \
     zsh-common \
+    fish \
     expect \
     curl \
     wget \
@@ -57,6 +58,31 @@ RUN curl -fsSL \
       https://github.com/aquaproj/aqua/releases/download/v${AQUA_VERSION}/aqua_linux_amd64.tar.gz \
     | tar -xz -C /usr/local/bin \
     && chmod +x /usr/local/bin/aqua
+
+# =====================
+# A tool no shell ships completions for
+# =====================
+# Fish bundles completions for a thousand commands, so every real tool
+# installed above is one fish can complete on its own. This one exists to
+# cover the opposite case - the tool dirvana is actually there for - and
+# it speaks the Cobra __complete protocol, nothing else.
+RUN printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [ "$1" = "__complete" ]; then' \
+    '  shift' \
+    '  if [ $# -le 1 ]; then' \
+    '    printf "alpha\\tThe alpha command\\n"' \
+    '    printf "beta\\tThe beta command\\n"' \
+    '  else' \
+    '    printf "nested-one\\tA nested value\\n"' \
+    '    printf "nested-two\\tAnother nested value\\n"' \
+    '  fi' \
+    '  printf ":4\\n"' \
+    '  exit 0' \
+    'fi' \
+    'echo "Usage: unpackaged-tool [command]"' \
+    > /usr/local/bin/unpackaged-tool \
+    && chmod +x /usr/local/bin/unpackaged-tool
 
 # =====================
 # Installation of native completions

--- a/tests/completion/scripts/test_fish_completion.sh
+++ b/tests/completion/scripts/test_fish_completion.sh
@@ -1,61 +1,37 @@
-#!/usr/bin/expect -f
-# Test fish completion for dirvana-managed aliases
+#!/usr/bin/env fish
+# Capture the completions fish offers for a dirvana-managed alias.
 #
-# Usage: test_fish_completion.sh <alias> <config_dir>
+# Usage: test_fish_completion.sh <alias> <config_dir> [subcommand]
 #
-# This script:
-# 1. Starts a fish shell
-# 2. Sources dirvana export
-# 3. Simulates TAB completion for the given alias
-# 4. Outputs the completions
+# Unlike bash and zsh, fish exposes completion as a plain command:
+# `complete -C"<line>"` returns exactly what TAB would offer. No expect,
+# no pseudo-terminal, no sleeping - so this reads the same result the
+# user gets, deterministically.
 
-set timeout 5
-set alias_name [lindex $argv 0]
-set config_dir [lindex $argv 1]
+set -l alias_name $argv[1]
+set -l config_dir $argv[2]
+set -l subcommand $argv[3]
 
-if {$alias_name == ""} {
-    send_user "Usage: test_fish_completion.sh <alias> <config_dir>\n"
+if test -z "$alias_name"
+    echo "Usage: test_fish_completion.sh <alias> <config_dir> [subcommand]" >&2
     exit 1
-}
+end
 
-# Start fish with no config files
-spawn fish --no-config
+if test -n "$config_dir"
+    cd $config_dir; or exit 1
+end
 
-# Wait for prompt
-expect {
-    timeout { send_user "TIMEOUT waiting for initial prompt\n"; exit 1 }
-    -re "> "
-}
+# Load the aliases and their completion registrations
+eval (dirvana export 2>/dev/null | string collect)
 
-# Navigate to config directory if provided
-if {$config_dir != ""} {
-    send "cd $config_dir\r"
-    expect {
-        timeout { send_user "TIMEOUT after cd\n"; exit 1 }
-        -re "> "
-    }
-}
+# Build the line being completed: "alias " or "alias subcommand "
+set -l line "$alias_name "
+if test -n "$subcommand"
+    set line "$alias_name $subcommand "
+end
 
-# Source dirvana export (fish syntax)
-send "eval (dirvana export)\r"
-expect {
-    timeout { send_user "TIMEOUT after dirvana export\n"; exit 1 }
-    -re "> "
-}
-
-# Trigger completion by typing the alias and TAB
-# Fish shows completions in a different format than bash/zsh
-send "$alias_name \t"
-
-# Wait a bit for completions to appear
-sleep 0.5
-
-# Capture the output
-expect {
-    timeout { send_user "TIMEOUT waiting for completions\n"; exit 1 }
-    -re "> "
-}
-
-# Exit fish
-send "exit\r"
-expect eof
+# Keep only the value of each suggestion; the parser splits on whitespace
+# and would otherwise take description words for completions
+echo "COMPLETIONS_START"
+complete -C"$line" | string replace -r '\t.*' ''
+echo "COMPLETIONS_END"

--- a/tests/completion/shell_integration_test.go
+++ b/tests/completion/shell_integration_test.go
@@ -24,10 +24,12 @@ var testShell = getTestShell()
 
 // Shell integration tests - test real completion in actual shells
 var shellIntegrationTests = []struct {
-	name           string
-	shell          string
-	alias          string
-	tool           string
+	name  string
+	shell string
+	alias string
+	tool  string
+	// subcommand completes "alias subcommand <TAB>" instead of "alias <TAB>"
+	subcommand     string
 	minCompletions int
 	shouldContain  []string
 }{
@@ -71,6 +73,57 @@ var shellIntegrationTests = []struct {
 		minCompletions: 15,
 		shouldContain:  []string{"init", "plan", "apply"},
 	},
+	// Fish reaches completions two ways, and both have to keep working.
+	//
+	// For a command fish knows - it bundles completions for over a
+	// thousand - `complete -w` forwards every level to them and dirvana
+	// stands aside.
+	{
+		name:           "kubectl-in-fish",
+		shell:          "fish",
+		alias:          "k",
+		tool:           "kubectl",
+		minCompletions: 30,
+		shouldContain:  []string{"get", "apply", "delete"},
+	},
+	{
+		name:           "kubectl-subcommand-in-fish",
+		shell:          "fish",
+		alias:          "k",
+		tool:           "kubectl",
+		subcommand:     "config",
+		minCompletions: 5,
+		shouldContain:  []string{"current-context", "use-context"},
+	},
+	// For a command it does not know, fish can only offer file names, so
+	// dirvana is the only source - from the very first word. v0.9.0 lost
+	// this case by standing down on the first token; these two catch it.
+	{
+		name:           "unpackaged-tool-in-fish",
+		shell:          "fish",
+		alias:          "ut",
+		tool:           "unpackaged-tool",
+		minCompletions: 2,
+		shouldContain:  []string{"alpha", "beta"},
+	},
+	{
+		name:           "unpackaged-tool-subcommand-in-fish",
+		shell:          "fish",
+		alias:          "ut",
+		tool:           "unpackaged-tool",
+		subcommand:     "alpha",
+		minCompletions: 2,
+		shouldContain:  []string{"nested-one", "nested-two"},
+	},
+	// The same tool in bash, where dirvana has always been the only source
+	{
+		name:           "unpackaged-tool-in-bash",
+		shell:          "bash",
+		alias:          "ut",
+		tool:           "unpackaged-tool",
+		minCompletions: 2,
+		shouldContain:  []string{"alpha", "beta"},
+	},
 }
 
 func TestShellIntegration_Completion(t *testing.T) {
@@ -106,7 +159,11 @@ func TestShellIntegration_Completion(t *testing.T) {
 			require.NoError(t, err)
 
 			// Run completion test script
-			cmd := exec.Command(scriptPath, tt.alias, configDir)
+			args := []string{tt.alias, configDir}
+			if tt.subcommand != "" {
+				args = append(args, tt.subcommand)
+			}
+			cmd := exec.Command(scriptPath, args...)
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Logf("Script output:\n%s", string(output))

--- a/tests/completion/testdata/.dirvana.yml
+++ b/tests/completion/testdata/.dirvana.yml
@@ -5,6 +5,8 @@ aliases:
   g:
     command: git
     completion: git
+  # A tool the shells ship no completions for: only dirvana can complete it
+  ut: unpackaged-tool
 
 functions:
   # Simple function with parameters


### PR DESCRIPTION
Fish had **no completion coverage at all**: the table in `shell_integration_test.go` held only bash and zsh, and `test_fish_completion.sh` was never called by anything.

That gap is what let the v0.9.0 fish regression through. Reverting the fix makes `unpackaged-tool-in-fish` fail, which is the point of adding these.

## Approach

The script no longer drives a pseudo-terminal through expect. Fish exposes completion as a plain command, so `complete -C"<line>"` returns exactly what TAB would offer — no sleeping, no prompt scraping, deterministic.

## Two cases that fail differently

| case | fish alone | who must answer |
|---|---|---|
| `kubectl` (fish ships completions for it) | forwards every level via `complete -w` | fish; dirvana stays out |
| `unpackaged-tool` (Cobra binary built into the image, no shell knows it) | file names only | dirvana, from the first word |

Both are checked at the first level and one level deeper, since that distinction is exactly what the previous fix got wrong. The unpackaged tool is covered in bash too, where dirvana has always been the only source.

## Test plan

- [x] `task test-completion TEST_SHELL=fish` — 4/4 pass
- [x] Reintroduced the v0.9.0 regression and confirmed `unpackaged-tool-in-fish` fails
- [x] Added a `completion-fish` job to the weekly workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)