### PR TITLE
fix(shell): survive set -u, and re-enable the zsh completion suite

### DIFF
--- a/.github/workflows/completion-tests.yml
+++ b/.github/workflows/completion-tests.yml
@@ -1,16 +1,23 @@
 name: Completion Tests
 
-# The expect-based completion suite is slow and environment-sensitive,
-# so it runs on demand and weekly instead of on every PR.
+# The completion suite drives real shells inside Docker, which is slow and
+# environment-sensitive, so it runs on demand and weekly instead of on
+# every PR.
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1' # Monday 06:00 UTC
 
 jobs:
-  completion-bash:
-    name: Bash completion suite
+  completion:
+    name: ${{ matrix.shell }} completion suite
     runs-on: ubuntu-latest
+    strategy:
+      # One shell failing says nothing about the others, and knowing
+      # whether a break is shell-specific is the whole point
+      fail-fast: false
+      matrix:
+        shell: [bash, zsh, fish]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -25,29 +32,7 @@ jobs:
         with:
           aqua_version: v2.62.3
 
-      - name: Run bash completion tests in Docker
+      - name: Run completion tests in Docker
         run: task test-completion
         env:
-          TEST_SHELL: bash
-
-  completion-fish:
-    name: Fish completion suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Set up aqua
-        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
-        with:
-          aqua_version: v2.55.1
-
-      - name: Run fish completion tests in Docker
-        run: task test-completion
-        env:
-          TEST_SHELL: fish
+          TEST_SHELL: ${{ matrix.shell }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -207,6 +207,9 @@ tasks:
       - echo "Testing completion in zsh..."
       - task: test-completion
         vars: { TEST_SHELL: "zsh" }
+      - echo "Testing completion in fish..."
+      - task: test-completion
+        vars: { TEST_SHELL: "fish" }
 
   generate-schema:
     desc: Generate JSON schema from Go structs

--- a/internal/shell/templates/completion/bash.tmpl
+++ b/internal/shell/templates/completion/bash.tmpl
@@ -92,7 +92,9 @@ __dirvana_format_descriptions() {
 }
 
 __dirvana_register_completion() {
-    local alias_name="$1"
+    # Guarded for the same reason as zsh: this is evaluated in the user's
+    # shell, which may run under `set -u`
+    local alias_name="${1:-}"
     # For bash, always use dirvana's completion function.
     # Native completion wrapping (complete -p / sed) is unreliable with bash aliases
     # because completion functions run the command name in subshells where aliases

--- a/internal/shell/templates/completion/zsh_function.tmpl
+++ b/internal/shell/templates/completion/zsh_function.tmpl
@@ -67,7 +67,11 @@ __dirvana_complete_zsh() {
 }
 
 __dirvana_register_completion() {
-    local alias_name="$1" underlying_cmd="$2"
+    # Defaults matter: this runs inside the user's shell, and aliases with
+    # no underlying command are registered with a single argument. Under
+    # `setopt no_unset` an unguarded $2 aborts the whole eval, taking
+    # every later registration with it.
+    local alias_name="${1:-}" underlying_cmd="${2:-}"
     if [[ -n "$underlying_cmd" ]]; then
         # Check if native completion exists (loaded or autoloadable)
         if (( ${+_comps[$underlying_cmd]} )) || whence -w "_${underlying_cmd}" &>/dev/null 2>&1; then

--- a/tests/completion/scripts/test_zsh_completion.sh
+++ b/tests/completion/scripts/test_zsh_completion.sh
@@ -1,132 +1,93 @@
-#!/usr/bin/expect -f
-# Test zsh completion for dirvana-managed aliases
+#!/usr/bin/env zsh
+# Capture the completions zsh offers for a dirvana-managed alias.
 #
-# Usage: test_zsh_completion.sh <alias> <config_dir>
+# Usage: test_zsh_completion.sh <alias> <config_dir> [subcommand]
 #
-# This script:
-# 1. Starts a zsh shell
-# 2. Sources dirvana export
-# 3. Simulates TAB completion for the given alias
-# 4. Outputs the completions
+# Zsh has no equivalent to fish's `complete -C`, and driving a terminal
+# through expect meant scraping a rendered screen - pagination, escape
+# codes and prompt guessing included, which is why these tests were
+# disabled. Instead we call the completion system the way zsh itself
+# does: look up the function registered for the alias, set the `words`
+# and `CURRENT` variables a real completion would see, and intercept the
+# builtins the function reports its matches through.
 
-set timeout 5
-set alias_name [lindex $argv 0]
-set config_dir [lindex $argv 1]
+emulate -L zsh
+setopt no_unset
 
-if {$alias_name == ""} {
-    send_user "Usage: test_zsh_completion.sh <alias> <config_dir>\n"
+local alias_name="${1:-}"
+local config_dir="${2:-}"
+local subcommand="${3:-}"
+
+if [[ -z "$alias_name" ]]; then
+    print -u2 "Usage: test_zsh_completion.sh <alias> <config_dir> [subcommand]"
     exit 1
+fi
+
+[[ -n "$config_dir" ]] && cd "$config_dir"
+
+autoload -Uz compinit && compinit -u 2>/dev/null
+
+# Load the aliases and their completion registrations. DIRVANA_SHELL is
+# explicit because this script is not run from an interactive zsh, so
+# shell auto-detection would look at the wrong parent process.
+eval "$(DIRVANA_SHELL=zsh dirvana export 2>/dev/null)"
+
+# Completion functions report matches through _describe or compadd.
+# Replacing both captures what the user would be offered, whether the
+# function is dirvana's own or the tool's native one.
+_describe() {
+    local arrname=${@[-1]}
+    local entry
+    for entry in ${(P)arrname}; do
+        # entries are "value:description"
+        print -- "${entry%%:*}"
+    done
+    return 0
 }
 
-# Start zsh with no rc files initially
-spawn zsh --no-rcs
-
-# Wait for prompt (can be % or hostname#)
-expect {
-    timeout { send_user "TIMEOUT waiting for initial prompt\n"; exit 1 }
-    -re {(%|#)}
+compadd() {
+    local -a values
+    local skip_next=0 arg
+    for arg in "$@"; do
+        if (( skip_next )); then
+            skip_next=0
+            continue
+        fi
+        case "$arg" in
+            # options carrying a value
+            -d|-X|-J|-V|-P|-S|-p|-s|-M|-W|-F|-i|-a) skip_next=1 ;;
+            -*) ;;
+            --) ;;
+            *) values+=("$arg") ;;
+        esac
+    done
+    print -l -- "${values[@]}"
+    return 0
 }
 
-# Configure zsh completion system
-send "autoload -Uz compinit\r"
-expect {
-    timeout { send_user "TIMEOUT after autoload compinit\n"; exit 1 }
-    -re {(%|#)}
-}
+# Never let a miss fall through to listing the filesystem
+_files() { return 1 }
+_message() { return 0 }
 
-send "compinit -i\r"
-expect {
-    timeout { send_user "TIMEOUT after compinit\n"; exit 1 }
-    -re {(%|#)}
-}
+# Build the line being completed, as the completion system would see it:
+# words holds the tokens, CURRENT is the 1-based index of the one being
+# completed - an empty trailing token when completing a fresh word.
+local -a words
+if [[ -n "$subcommand" ]]; then
+    words=("$alias_name" "$subcommand" "")
+else
+    words=("$alias_name" "")
+fi
+local CURRENT=${#words}
 
-# Disable the "do you wish to see all N possibilities" prompt
-# Set LISTMAX to a very high number so zsh never asks
-send "LISTMAX=9999\r"
-expect {
-    timeout { send_user "TIMEOUT after LISTMAX\n"; exit 1 }
-    -re {(%|#)}
-}
+# Use whatever zsh registered for this alias: dirvana's function, or the
+# tool's native completion when dirvana delegated to it
+local comp_func=${_comps[$alias_name]:-}
+if [[ -z "$comp_func" ]]; then
+    print -u2 "no completion registered for '$alias_name'"
+    exit 1
+fi
 
-# Load native tool completions
-send "kubectl completion zsh > /tmp/_kubectl && source /tmp/_kubectl 2>/dev/null || true\r"
-expect {
-    timeout { send_user "TIMEOUT after kubectl completion\n"; exit 1 }
-    -re {(%|#)}
-}
-
-send "terraform -install-autocomplete 2>/dev/null || true\r"
-expect {
-    timeout { send_user "TIMEOUT after terraform autocomplete\n"; exit 1 }
-    -re {(%|#)}
-}
-
-send "aqua completion zsh > /tmp/_aqua && source /tmp/_aqua 2>/dev/null || true\r"
-expect {
-    timeout { send_user "TIMEOUT after aqua completion\n"; exit 1 }
-    -re {(%|#)}
-}
-
-# Change to config directory
-send "cd $config_dir\r"
-expect {
-    timeout { send_user "TIMEOUT after cd command\n"; exit 1 }
-    -re {(%|#)}
-}
-
-# Allow directory (suppress authorization prompt and output)
-send "dirvana allow >/dev/null 2>&1\r"
-expect {
-    timeout { send_user "TIMEOUT after dirvana allow\n"; exit 1 }
-    -re {(%|#)}
-}
-
-# Export dirvana environment
-send "eval \"\$(dirvana export)\"\r"
-expect {
-    timeout { send_user "TIMEOUT after dirvana export\n"; exit 1 }
-    -re {(%|#)}
-}
-
-# Trigger completion (send alias + space + double TAB)
-send "$alias_name \t\t"
-
-# Wait a bit for completions to appear and capture them
-set output ""
-expect {
-    -timeout 30
-    timeout {
-        send_user "TIMEOUT waiting for completions after 30s\n"
-        exit 1
-    }
-    -ex {--More--} {
-        # Paged output - accumulate what we have so far and send Ctrl+C
-        append output $expect_out(buffer)
-        send "\x03"
-        exp_continue
-    }
-    -re {(%|#)} {
-        # Got back to prompt - accumulate final output
-        append output $expect_out(buffer)
-    }
-}
-
-# If we didn't get back to prompt yet, wait for it after Ctrl+C
-if {![string match "*%*" $output] && ![string match "*#*" $output]} {
-    send "\x03"
-    expect {
-        timeout { send_user "TIMEOUT after Ctrl+C\n"; exit 1 }
-        -re {(%|#)}
-    }
-}
-
-# Print captured completions to stdout (not to spawned shell)
-send_user "COMPLETIONS_START\n"
-send_user -- $output
-send_user "\n"
-send_user "COMPLETIONS_END\n"
-
-# Exit shell
-send "\025" ;# Ctrl+U to clear line
-send "exit\r"
-expect eof
+print "COMPLETIONS_START"
+$comp_func 2>/dev/null
+print "COMPLETIONS_END"

--- a/tests/completion/shell_integration_test.go
+++ b/tests/completion/shell_integration_test.go
@@ -73,6 +73,34 @@ var shellIntegrationTests = []struct {
 		minCompletions: 15,
 		shouldContain:  []string{"init", "plan", "apply"},
 	},
+	{
+		name:           "kubectl-subcommand-in-zsh",
+		shell:          "zsh",
+		alias:          "k",
+		tool:           "kubectl",
+		subcommand:     "config",
+		minCompletions: 5,
+		shouldContain:  []string{"current-context", "use-context"},
+	},
+	// zsh delegates to a tool's own completion when it has one, so the
+	// unpackaged tool is what proves dirvana is reached at all
+	{
+		name:           "unpackaged-tool-in-zsh",
+		shell:          "zsh",
+		alias:          "ut",
+		tool:           "unpackaged-tool",
+		minCompletions: 2,
+		shouldContain:  []string{"alpha", "beta"},
+	},
+	{
+		name:           "unpackaged-tool-subcommand-in-zsh",
+		shell:          "zsh",
+		alias:          "ut",
+		tool:           "unpackaged-tool",
+		subcommand:     "alpha",
+		minCompletions: 2,
+		shouldContain:  []string{"nested-one", "nested-two"},
+	},
 	// Fish reaches completions two ways, and both have to keep working.
 	//
 	// For a command fish knows - it bundles completions for over a
@@ -144,10 +172,6 @@ func TestShellIntegration_Completion(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			// TODO: Fix zsh expect script - completion works manually but expect has issues capturing output
-			if tt.shell == "zsh" {
-				t.Skip("Zsh completion tests temporarily disabled due to expect script issues")
-			}
 			t.Logf("Testing %s completion in %s", tt.alias, tt.shell)
 
 			// Get absolute path to config dir


### PR DESCRIPTION
## A real bug, found by writing the test

`__dirvana_register_completion` read `$2` with no default. Aliases with no underlying command are registered with a single argument, so under zsh's `setopt no_unset` — or bash's `set -u` — the eval aborted right there and **every later registration was lost**:

```
__dirvana_register_completion:1: 2: parameter not set
no completion registered for 'ut'
```

This code is evaluated inside the user's shell, so it has to hold under whatever options they set. Both templates now default their arguments. Verified in the container with `setopt no_unset` and with `set -u`.

## Re-enabling the zsh suite

The zsh cases carried a TODO and a skip: completion worked by hand, but the expect script could not capture it. It was scraping a rendered terminal — pagination, escape codes, prompt guessing.

Zsh has no `complete -C` like fish, but it does not need a terminal either. The script now:

1. looks up the function zsh registered for the alias (`$_comps[alias]`),
2. sets the `words` and `CURRENT` variables a real completion would see,
3. replaces `_describe` and `compadd` to capture what would be offered.

That works whether the function is dirvana's own or the tool's native one — which matters, because zsh delegates via `compdef alias=cmd` when the tool has its own completions.

```
--- PASS: kubectl-in-zsh
--- PASS: terraform-in-zsh
--- PASS: kubectl-subcommand-in-zsh
--- PASS: unpackaged-tool-in-zsh
--- PASS: unpackaged-tool-subcommand-in-zsh
```

The script keeps `no_unset` on, so the guard added above stays honest.

## Workflow

The weekly run covered bash only, then bash and fish. The three jobs are now a single matrix with `fail-fast: false` — a break in one shell says nothing about the others. This also picks up the action versions the fish job was still pinned to, since #36 branched before #37 landed.

## Test plan

- [x] `task test-completion` for bash (6), zsh (5), fish (4) — all pass
- [x] `go test -race ./...`, `golangci-lint run` (0 issues)
- [x] `eval "$(dirvana export)"` under `setopt no_unset` and under `set -u`, registrations verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)