### PR TITLE
fix(auth): identify a project by its directory, not by the path used to reach it

### DIFF
--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -41,13 +41,19 @@ shown and consented to in the same interaction. You will only be prompted
 again when those commands change. `--auto-approve-shell` skips the prompt
 (useful for CI).
 
+An authorization applies to the directory itself, not to the path used to
+reach it: symlinks are resolved, so authorizing `~/work` when it points at
+`/mnt/data/project` authorizes that project under either name. Repointing the
+symlink elsewhere does not carry the authorization over — the new target is a
+different directory, and has to be authorized on its own.
+
 ### `dirvana revoke [path]`
 
 Removes authorization for a directory and invalidates its cache (including subdirectories).
 
 ### `dirvana list`
 
-Lists all authorized directories.
+Lists all authorized directories, by the path their symlinks resolve to.
 
 ## Configuration
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -22,8 +21,37 @@ const currentAuthVersion = 2
 func (a *Auth) GetAuth(path string) *DirAuth {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	normalized := normalizePath(path)
-	return a.authorized[normalized]
+	auth, _ := a.lookup(path)
+	return auth
+}
+
+// lookup finds the entry for a directory under the name given or under the one
+// every symlink along it resolves to, and returns the key it was filed under -
+// or the key a new entry should take.
+//
+// An authorization identifies a directory, not one of the names leading to it:
+// a shell keeps the logical path in $PWD and os.Getwd honours it, so the same
+// project reaches dirvana under whichever name the user typed. Looking the
+// literal name up first keeps entries written by earlier versions working.
+//
+// The caller must hold the lock.
+func (a *Auth) lookup(path string) (*DirAuth, string) {
+	normalized := fsutil.NormalizePath(path)
+	if auth := a.authorized[normalized]; auth != nil {
+		return auth, normalized
+	}
+
+	resolved := fsutil.ResolvePath(path)
+	if resolved != normalized {
+		if auth := a.authorized[resolved]; auth != nil {
+			return auth, resolved
+		}
+	}
+
+	// Nothing yet: a new entry is filed under the resolved name, so it holds
+	// wherever the directory is reached from - and stops holding if the
+	// symlink that led to it is later pointed somewhere else
+	return nil, resolved
 }
 
 // RequiresShellApproval returns true if shell command approval is needed for the directory
@@ -58,8 +86,7 @@ func hashShellCommands(cmds map[string]string) string {
 func (a *Auth) ApproveShellCommands(dir string, shellCmds map[string]string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	normalized := normalizePath(dir)
-	auth := a.authorized[normalized]
+	auth, _ := a.lookup(dir)
 	if auth == nil {
 		return fmt.Errorf("directory not authorized")
 	}
@@ -114,22 +141,22 @@ func (a *Auth) Allow(path string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	normalized := normalizePath(path)
+	existing, key := a.lookup(path)
 
 	// Check if already allowed - idempotent operation
-	if existing := a.authorized[normalized]; existing != nil && existing.Allowed {
+	if existing != nil && existing.Allowed {
 		return nil
 	}
 
 	now := time.Now()
-	if a.authorized[normalized] == nil {
-		a.authorized[normalized] = &DirAuth{
+	if existing == nil {
+		a.authorized[key] = &DirAuth{
 			Allowed:   true,
 			AllowedAt: now,
 		}
 	} else {
-		a.authorized[normalized].Allowed = true
-		a.authorized[normalized].AllowedAt = now
+		existing.Allowed = true
+		existing.AllowedAt = now
 	}
 	return a.persist()
 }
@@ -139,8 +166,7 @@ func (a *Auth) IsAllowed(path string) (bool, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	normalized := normalizePath(path)
-	auth := a.authorized[normalized]
+	auth, _ := a.lookup(path)
 	return auth != nil && auth.Allowed, nil
 }
 
@@ -149,8 +175,10 @@ func (a *Auth) Revoke(path string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	normalized := normalizePath(path)
-	delete(a.authorized, normalized)
+	// Both spellings go: an entry left under the other one would keep the
+	// directory authorized after the user asked for that to stop
+	delete(a.authorized, fsutil.NormalizePath(path))
+	delete(a.authorized, fsutil.ResolvePath(path))
 	return a.persist()
 }
 
@@ -194,7 +222,7 @@ func (a *Auth) load() error {
 	a.authorized = make(map[string]*DirAuth)
 	for path, auth := range authFile.Directories {
 		if auth != nil {
-			a.authorized[normalizePath(path)] = auth
+			a.authorized[fsutil.NormalizePath(path)] = auth
 		}
 	}
 
@@ -213,10 +241,4 @@ func (a *Auth) persist() error {
 		return err
 	}
 	return fsutil.AtomicWrite(a.path, data, fsutil.StateFilePerm)
-}
-
-// normalizePath removes trailing slashes and cleans the path
-func normalizePath(path string) string {
-	cleaned := filepath.Clean(path)
-	return strings.TrimSuffix(cleaned, "/")
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -398,4 +399,121 @@ func TestAuth_Load_EdgeCases(t *testing.T) {
 		assert.NotNil(t, a)
 		assert.Empty(t, a.List())
 	})
+}
+
+// symlinkedProject returns a directory and a symlink pointing at it, the shape
+// of a project reached through ~/work -> /mnt/data/work.
+func symlinkedProject(t *testing.T) (target, link string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	target = filepath.Join(tmp, "project")
+	link = filepath.Join(tmp, "link")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	require.NoError(t, os.Symlink(target, link))
+	return target, link
+}
+
+// TestAuth_SymlinkedPathIsTheSameProject covers what an authorization means: a
+// directory, not the name used to reach it. Authorizing one spelling and
+// arriving through the other used to be refused, with no way to tell why.
+func TestAuth_SymlinkedPathIsTheSameProject(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		allowed, tried func(target, link string) string
+	}{
+		{
+			"allow target, arrive by link",
+			func(target, _ string) string { return target },
+			func(_, link string) string { return link },
+		},
+		{
+			"allow link, arrive by target",
+			func(_, link string) string { return link },
+			func(target, _ string) string { return target },
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target, link := symlinkedProject(t)
+			a, err := New(filepath.Join(t.TempDir(), "authorized.json"))
+			require.NoError(t, err)
+
+			require.NoError(t, a.Allow(tt.allowed(target, link)))
+
+			allowed, err := a.IsAllowed(tt.tried(target, link))
+			require.NoError(t, err)
+			assert.True(t, allowed)
+		})
+	}
+}
+
+func TestAuth_RevokeReachesBothSpellings(t *testing.T) {
+	target, link := symlinkedProject(t)
+	a, err := New(filepath.Join(t.TempDir(), "authorized.json"))
+	require.NoError(t, err)
+
+	require.NoError(t, a.Allow(link))
+	require.NoError(t, a.Revoke(target))
+
+	// Revoking has to mean revoked, whichever name either side used
+	for _, path := range []string{target, link} {
+		allowed, err := a.IsAllowed(path)
+		require.NoError(t, err)
+		assert.False(t, allowed, "still authorized through %s", path)
+	}
+}
+
+// TestAuth_DoesNotFollowARepointedSymlink is the security half of resolving:
+// an authorization is pinned to the directory it was granted for, so pointing
+// the symlink somewhere else does not carry it over.
+func TestAuth_DoesNotFollowARepointedSymlink(t *testing.T) {
+	target, link := symlinkedProject(t)
+	other := filepath.Join(filepath.Dir(target), "other")
+	require.NoError(t, os.Mkdir(other, 0o755))
+
+	a, err := New(filepath.Join(t.TempDir(), "authorized.json"))
+	require.NoError(t, err)
+	require.NoError(t, a.Allow(link))
+
+	require.NoError(t, os.Remove(link))
+	require.NoError(t, os.Symlink(other, link))
+
+	allowed, err := a.IsAllowed(link)
+	require.NoError(t, err)
+	assert.False(t, allowed, "the authorization was granted for another directory")
+}
+
+// TestAuth_HonoursEntriesWrittenBeforeResolving keeps upgrades quiet: releases
+// up to v0.10.0 filed entries under the literal path, and those must keep
+// working rather than silently asking for authorization again.
+func TestAuth_HonoursEntriesWrittenBeforeResolving(t *testing.T) {
+	_, link := symlinkedProject(t)
+	authPath := filepath.Join(t.TempDir(), "authorized.json")
+
+	legacy := fmt.Sprintf(`{"_version": 2, "directories": {%q: {"allowed": true}}}`, link)
+	require.NoError(t, os.WriteFile(authPath, []byte(legacy), 0o600))
+
+	a, err := New(authPath)
+	require.NoError(t, err)
+
+	allowed, err := a.IsAllowed(link)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	// And approving shell commands finds that entry rather than creating a
+	// second one under the resolved name
+	require.NoError(t, a.ApproveShellCommands(link, map[string]string{"BRANCH": "git branch"}))
+	assert.Len(t, a.List(), 1)
+}
+
+func TestAuth_AllowIsIdempotentAcrossSpellings(t *testing.T) {
+	target, link := symlinkedProject(t)
+	a, err := New(filepath.Join(t.TempDir(), "authorized.json"))
+	require.NoError(t, err)
+
+	require.NoError(t, a.Allow(target))
+	require.NoError(t, a.Allow(link))
+	require.NoError(t, a.Allow(target+"/"))
+
+	assert.Len(t, a.List(), 1, "one directory, one entry")
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -72,8 +72,15 @@ func (c *Cache) Get(path string) (*Entry, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	entry, found := c.entries[path]
+	entry, found := c.entries[cacheKey(path)]
 	return entry, found
+}
+
+// cacheKey is how a directory is identified here: the same identity auth uses,
+// so reaching a project through a symlink and through its real path shares one
+// entry instead of building two.
+func cacheKey(path string) string {
+	return fsutil.ResolvePath(path)
 }
 
 // Set stores an entry in cache and persists it
@@ -81,6 +88,9 @@ func (c *Cache) Set(entry *Entry) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// The stored path is keyed the same way, so the hierarchy walks below
+	// compare like with like
+	entry.Path = cacheKey(entry.Path)
 	c.entries[entry.Path] = entry
 	return c.persist()
 }
@@ -90,7 +100,7 @@ func (c *Cache) Delete(path string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	delete(c.entries, path)
+	delete(c.entries, cacheKey(path))
 	return c.persist()
 }
 
@@ -108,15 +118,14 @@ func (c *Cache) ClearHierarchy(dir string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Normalize path
-	dir = filepath.Clean(dir)
+	dir = cacheKey(dir)
 
 	// Track which entries to delete
 	toDelete := []string{}
 
 	for path := range c.entries {
 		// Delete if path is the directory or is within its hierarchy
-		cleanPath := filepath.Clean(path)
+		cleanPath := fsutil.NormalizePath(path)
 		if cleanPath == dir || isParentOf(dir, cleanPath) || isParentOf(cleanPath, dir) {
 			toDelete = append(toDelete, path)
 		}
@@ -137,15 +146,14 @@ func (c *Cache) DeleteWithSubdirs(dir string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Normalize path
-	dir = filepath.Clean(dir)
+	dir = cacheKey(dir)
 
 	// Track which entries to delete
 	toDelete := []string{}
 
 	for path := range c.entries {
 		// Delete if path is the directory or is a subdirectory
-		cleanPath := filepath.Clean(path)
+		cleanPath := fsutil.NormalizePath(path)
 		if cleanPath == dir || isParentOf(dir, cleanPath) {
 			toDelete = append(toDelete, path)
 		}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -356,4 +357,33 @@ func TestCache_DeleteWithSubdirs_EmptyCache(t *testing.T) {
 	// Should not error on empty cache
 	err = c.DeleteWithSubdirs("/home/user/project")
 	require.NoError(t, err)
+}
+
+// TestCache_SymlinkedPathSharesOneEntry keeps the cache keyed the way auth
+// identifies a directory: reaching a project through a symlink and through its
+// target path is the same project, so it must not be computed twice.
+func TestCache_SymlinkedPathSharesOneEntry(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "project")
+	link := filepath.Join(tmp, "link")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	require.NoError(t, os.Symlink(target, link))
+
+	c, err := New(filepath.Join(tmp, "cache.json"))
+	require.NoError(t, err)
+
+	require.NoError(t, c.Set(&Entry{Path: link, Hash: "h", Version: "v1"}))
+
+	entry, found := c.Get(target)
+	require.True(t, found, "the entry filed through the symlink must be found by the target path")
+	assert.Equal(t, "h", entry.Hash)
+	assert.True(t, c.IsValid(target, "h", "v1"))
+
+	// And one entry, not two
+	require.NoError(t, c.Set(&Entry{Path: target, Hash: "h2", Version: "v1"}))
+	assert.Len(t, c.entries, 1)
+
+	require.NoError(t, c.Delete(link))
+	_, found = c.Get(target)
+	assert.False(t, found, "deleting through either name removes the entry")
 }

--- a/internal/fsutil/path.go
+++ b/internal/fsutil/path.go
@@ -1,0 +1,35 @@
+package fsutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// NormalizePath cleans a path and drops any trailing separator, so that two
+// spellings of the same name compare equal. It never touches the filesystem.
+func NormalizePath(path string) string {
+	cleaned := filepath.Clean(path)
+	if cleaned == string(filepath.Separator) {
+		// The root is all separator; trimming it would leave nothing
+		return cleaned
+	}
+	return strings.TrimSuffix(cleaned, string(filepath.Separator))
+}
+
+// ResolvePath returns a path with every symlink along it resolved, which is
+// what identifies a directory rather than one of the names leading to it.
+//
+// A shell keeps the logical path in $PWD and os.Getwd honours it, so the same
+// directory reaches dirvana under whichever name the user typed - the one they
+// authorised, or another one entirely.
+//
+// Falls back to NormalizePath when the path cannot be resolved: it may not
+// exist yet, or sit behind a directory the user cannot traverse, and neither
+// is a reason to refuse an answer.
+func ResolvePath(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return NormalizePath(path)
+	}
+	return NormalizePath(resolved)
+}

--- a/internal/fsutil/path_test.go
+++ b/internal/fsutil/path_test.go
@@ -1,0 +1,46 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/a/b", "/a/b"},
+		{"/a/b/", "/a/b"},
+		{"/a//b", "/a/b"},
+		{"/a/./b", "/a/b"},
+		{"/a/c/../b", "/a/b"},
+		{"/", string(filepath.Separator)},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, NormalizePath(tt.input), "NormalizePath(%q)", tt.input)
+	}
+}
+
+func TestResolvePath_FollowsSymlinks(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "target")
+	link := filepath.Join(tmp, "link")
+	require.NoError(t, os.Mkdir(target, 0o755))
+	require.NoError(t, os.Symlink(target, link))
+
+	// Both names have to land on the same answer: that is what makes an
+	// authorization identify a directory rather than a way of reaching it
+	assert.Equal(t, ResolvePath(target), ResolvePath(link))
+	assert.Equal(t, ResolvePath(filepath.Join(link, "..", "target")), ResolvePath(target))
+}
+
+func TestResolvePath_FallsBackWhenItCannotResolve(t *testing.T) {
+	// A path that does not exist yet still deserves an answer, cleaned
+	assert.Equal(t, "/nowhere/at/all", ResolvePath("/nowhere/at//all/"))
+}


### PR DESCRIPTION
Follow-up to #40. While fixing a macOS-only test failure there I claimed auth
resolved symlinks and the cache did not. That was wrong — `EvalSymlinks`
appeared nowhere in the codebase. Measuring properly turned up a different,
real problem.

## The actual bug

An authorization was tied to the path used to reach a project, not to the
project:

```console
$ dirvana allow /mnt/data/project
$ cd ~/work                        # symlink to /mnt/data/project
$ dirvana status
… not authorized
   run 'dirvana allow ~/work' to load them
```

Same directory, same `.dirvana.yml`, refused — and the same in reverse. The
reason `os.Getwd()` is involved: a shell keeps the logical path in `$PWD` and
Go honours it, so dirvana sees whichever name the user typed.

## What changed

Symlinks are resolved before an authorization is recorded or looked up, through
a helper `auth` and `cache` now share (`fsutil.NormalizePath` /
`fsutil.ResolvePath`).

**Existing authorizations keep working.** Releases up to v0.10.0 filed entries
under the literal path, so a lookup tries that spelling first before the
resolved one. Nothing is migrated or rewritten. `revoke` removes both.

**It also narrows what an authorization covers.** Before, it was granted to a
*name*: repointing a symlink carried the authorization over to whatever it led
to next. It is now pinned to the directory it was granted for — verified in
`TestAuth_DoesNotFollowARepointedSymlink`.

The cache is keyed the same way. It applied no normalisation at all until now,
not even `Clean`, so one project reached under two names was computed twice.

## Verification

Checked by hand with a real symlinked project, all four directions:

| Scenario | Before | After |
|---|---|---|
| allow real path, enter via symlink | not authorized | authorized |
| allow symlink, enter via real path | not authorized | authorized |
| revoke via one name, check the other | still authorized | revoked |
| repoint symlink at another directory | authorized (!) | not authorized |
| entry written by v0.10.0 under the literal path | authorized | authorized |

Plus unit tests for each, `-race` clean on the three touched packages, `task
lint` clean, full suite green. `EvalSymlinks` costs ~4 µs and runs a handful of
times per `cd`.

`NormalizePath` also fixes a pre-existing edge: `/` normalised to the empty
string, since trimming the trailing separator left nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)