### PR TITLE
fix(completion): stop asking dirvana for tools fish completes with short flags

### DIFF
--- a/internal/shell/generators_test.go
+++ b/internal/shell/generators_test.go
@@ -426,9 +426,13 @@ func TestFishCodeGenerator_GenerateCompletionFunction_DefersToFishWhenCovered(t 
 	assert.Contains(t, script, "function __dirvana_fish_covers")
 	assert.Contains(t, script, `if test -n "$underlying_cmd"; and __dirvana_fish_covers $underlying_cmd`)
 
-	// The probe must ask for long flags: file names never match them, so a
-	// non-empty answer proves the command has completions of its own
-	assert.Contains(t, script, `complete -C"$cmd --"`)
+	// The probe compares what fish offers against what it offers for a
+	// command it has never heard of. Asking for `--` completions answered
+	// "no" for every tool whose flags take a single dash, terraform included,
+	// so dirvana paid a fork per keypress for commands fish completes itself.
+	assert.Contains(t, script, `complete -C"__dirvana_unknown_command__ "`)
+	assert.Contains(t, script, `complete -C"$cmd "`)
+	assert.NotContains(t, script, `complete -C"$cmd --"`)
 
 	// And it must be answered once per command, not on every keypress
 	assert.Contains(t, script, "set -g $answer")
@@ -459,12 +463,12 @@ func TestFishCodeGenerator_GenerateCompletionFunction_SelfNamedAlias(t *testing.
 	// "maximum recursion depth, possible cycle?" right under the prompt.
 	probe := script[strings.Index(script, "function __dirvana_fish_covers"):]
 	probe = probe[:strings.Index(probe, "\nend")]
-	assert.Regexp(t, `(?s)set -g \$probing 1.*complete -C"\$cmd --"`, probe,
+	assert.Regexp(t, `(?s)set -g \$probing 1.*complete -C"\$cmd "`, probe,
 		"the re-entrancy marker must be set before probing, not after")
 
 	// An interrupted probe must leave no verdict: the marker is what gets
 	// cleared, and only the outer call ever records an answer
-	assert.Regexp(t, `(?s)complete -C"\$cmd --".*set -e \$probing.*set -g \$answer`, probe,
+	assert.Regexp(t, `(?s)complete -C"\$cmd ".*set -e \$probing.*set -g \$answer`, probe,
 		"a verdict recorded before the probe returns would outlive an interrupt")
 	assert.Contains(t, script, "string match '__dirvana_fish_probing_*'",
 		"a marker left by an interrupted probe must be cleared on the next cd")

--- a/internal/shell/templates/completion/fish_function.tmpl
+++ b/internal/shell/templates/completion/fish_function.tmpl
@@ -18,9 +18,15 @@ set -e __dirvana_stale_probe
 # completions exist, fish offers plain file names and dirvana is the only
 # thing that can help - from the very first word.
 #
-# The probe asks for long-flag completions: file names never match `--`,
-# so anything coming back proves real completions exist. The answer is
-# kept for the session, since it cannot change under a running shell.
+# The probe compares what fish offers for the command against what it
+# offers for a command it has never heard of, which is exactly the file
+# names of the current directory. Anything else proves real completions
+# exist. Asking for `--` completions instead looked cheaper but answered
+# "no" for every tool whose flags take a single dash - terraform among
+# them, which fish knows 22 subcommands of.
+#
+# The answer is kept for the session, since it cannot change under a
+# running shell.
 function __dirvana_fish_covers -a cmd
   set -l key (string replace -a -r '[^a-zA-Z0-9_]' _ -- $cmd)
   set -l answer __dirvana_fish_covers_$key
@@ -43,11 +49,14 @@ function __dirvana_fish_covers -a cmd
   end
 
   set -g $probing 1
-  set -l found (count (complete -C"$cmd --"))
+  # What fish falls back to for a command it knows nothing about: the file
+  # names of this directory, whatever they happen to be
+  set -l fallback (complete -C"__dirvana_unknown_command__ ")
+  set -l offered (complete -C"$cmd ")
   set -e $probing
 
   set -g $answer 0
-  if test $found -gt 0
+  if test "$offered" != "$fallback"
     set -g $answer 1
   end
 

--- a/tests/completion/scripts/test_fish_coverage.sh
+++ b/tests/completion/scripts/test_fish_coverage.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env fish
+# Report whether dirvana considers each command already covered by fish.
+#
+# Usage: test_fish_coverage.sh <config_dir> <command>...
+#
+# This is the decision that keeps dirvana out of the way: when fish knows a
+# command, `complete -w` forwards to its completions and asking dirvana would
+# cost a fork and a run of the tool on every keypress - a few hundred
+# milliseconds, felt at the prompt.
+
+set -l config_dir $argv[1]
+set -l commands $argv[2..-1]
+
+if test -z "$config_dir"
+    echo "Usage: test_fish_coverage.sh <config_dir> <command>..." >&2
+    exit 1
+end
+
+cd $config_dir; or exit 1
+
+eval (dirvana export 2>/dev/null | string collect)
+
+echo "COVERAGE_START"
+for cmd in $commands
+    if __dirvana_fish_covers $cmd
+        echo "$cmd covered"
+    else
+        echo "$cmd uncovered"
+    end
+end
+echo "COVERAGE_END"

--- a/tests/completion/shell_integration_test.go
+++ b/tests/completion/shell_integration_test.go
@@ -400,3 +400,39 @@ func parseCompletionOutput(output string) []string {
 
 	return unique
 }
+
+// TestShellIntegration_FishCoverageProbe pins the decision that keeps dirvana
+// out of fish's way. Getting it wrong is not a broken completion but a slow
+// one: dirvana is asked on every keypress for a command fish completes itself,
+// which costs a fork plus a run of the tool.
+//
+// The first shape of this probe asked for `--` completions, which answered
+// "uncovered" for every tool whose flags take a single dash. terraform is one,
+// and fish knows 22 of its subcommands - completing `tf ` went from 10ms to
+// over 300ms because of it.
+func TestShellIntegration_FishCoverageProbe(t *testing.T) {
+	if os.Getenv("TEST_SHELL") == "" {
+		t.Skip("Skipping shell integration tests (run with task test-completion in Docker)")
+	}
+	if testShell != "fish" {
+		t.Skip("The coverage probe is fish-specific")
+	}
+
+	setupTestEnvironment(t)
+
+	configDir, err := filepath.Abs("testdata")
+	require.NoError(t, err)
+	scriptPath, err := filepath.Abs(filepath.Join("scripts", "test_fish_coverage.sh"))
+	require.NoError(t, err)
+
+	// terraform and kubectl ship fish completions; unpackaged-tool is the one
+	// nothing knows about, so dirvana has to answer for it
+	output, err := exec.Command(scriptPath, configDir, "terraform", "kubectl", "unpackaged-tool").CombinedOutput()
+	require.NoError(t, err, "coverage probe failed:\n%s", string(output))
+
+	assert.Contains(t, string(output), "terraform covered",
+		"fish completes terraform, so dirvana must not be asked on every keypress")
+	assert.Contains(t, string(output), "kubectl covered")
+	assert.Contains(t, string(output), "unpackaged-tool uncovered",
+		"nothing else can complete it, so dirvana has to answer")
+}


### PR DESCRIPTION
Reported as `tf <tab>` and `k <tab>` taking seconds before showing anything.

## Measured first

In a real project, with the completion code loaded:

| | before | fish alone |
|---|---|---|
| `tf ` | 317 ms | **6 ms** |
| `k ` | 461 ms | 512 ms |

So the two cases are not the same problem. `k` is not dirvana at all — fish
answers for kubectl in 512 ms on its own, because kubectl's completion asks the
cluster. `tf` was dirvana, adding ~310 ms to something fish did in 6.

## Why

The probe deciding whether fish already covers a command asked it for `--`
completions, reasoning that file names never match that prefix. True — but
plenty of commands have no long flags either:

```
terraform '--' => 0     '-' => 1
ping      '--' => 0     '-' => 34
```

terraform takes `-out`, `-var`, `-state`, so the probe answered "not covered"
for a tool fish knows 22 subcommands of, and dirvana was asked on every
keypress: a fork plus a run of the tool.

## The fix

Compare what fish offers for the command against what it offers for a command
it has never heard of — exactly the file names of the current directory.
Anything else proves real completions exist, whatever shape the flags take.

Switching the probe to `-` instead would have been simpler and wrong: in a
directory holding a file whose name starts with a dash, it finds one completion
and concludes the command is covered. The comparison holds there, verified.

`tf ` measured after: **35 ms**.

## Other shells

Checked rather than assumed:

- **zsh** is unaffected. It tests whether a completion actually exists
  (`_comps[cmd]`) and delegates natively when it does — an alias to git
  resolves to `_git`, an unknown tool to dirvana. No heuristic, no false
  negative.
- **bash** does not have this bug but pays more broadly: it registers
  `__dirvana_complete` for every alias, known command or not, at ~290 ms per
  tab. That is deliberate and documented — bash runs completion functions in
  subshells where aliases do not expand, so it has no equivalent of
  `compdef alias=cmd` or `complete -w`. Worth revisiting separately.

## Verification

`TestShellIntegration_FishCoverageProbe` pins the decision itself rather than
its symptom: terraform and kubectl covered, unpackaged-tool not. Reverted the
template to check it fails without the fix — it reports `terraform uncovered`.

Full suite, three shells, `task lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)