### PR TITLE
fix(completion): bound the registry download that runs while the user waits

### DIFF
--- a/internal/completion/registry.go
+++ b/internal/completion/registry.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -30,7 +31,23 @@ const (
 	MaxRegistrySize = 1 * 1024 * 1024
 	// MaxScriptSize is the maximum size for downloaded completion script (5MB)
 	MaxScriptSize = 5 * 1024 * 1024
+
+	// DownloadTimeout bounds a download that happens while the user is waiting
+	// at the prompt: the registry is fetched during a completion, not ahead of
+	// it. Fetching it takes 100-400ms on a working connection, so this leaves
+	// room to spare - what it rules out is the unbounded wait of a network
+	// that accepts the connection and never answers.
+	DownloadTimeout = 2 * time.Second
+
+	// DownloadRetryAfter is how long a network failure is remembered. Every
+	// completion runs in its own process, so an in-memory note would be lost
+	// and the timeout above paid again on every single keypress.
+	DownloadRetryAfter = 10 * time.Minute
 )
+
+// errDownloadPaused reports that the network was tried recently and failed, so
+// this completion will not wait on it again.
+var errDownloadPaused = errors.New("download paused after a recent network failure")
 
 // DevMode is set by ldflags during dev builds
 // Production builds will have this as empty string
@@ -53,8 +70,10 @@ type Registry struct {
 func NewRegistry(cacheDir string) *Registry {
 	return &Registry{
 		cacheDir: cacheDir,
-		client:   http.DefaultClient,
-		baseURL:  RegistryBaseURL,
+		// Not http.DefaultClient: it has no timeout at all, and this runs
+		// while the user waits at the prompt
+		client:  &http.Client{Timeout: DownloadTimeout},
+		baseURL: RegistryBaseURL,
 	}
 }
 
@@ -122,11 +141,19 @@ func isLoopbackHost(host string) bool {
 
 // downloadWithSizeLimit downloads data with a size limit
 func (r *Registry) downloadWithSizeLimit(url string, maxSize int64) ([]byte, error) {
+	if r.downloadRecentlyFailed() {
+		return nil, errDownloadPaused
+	}
+
 	resp, err := r.client.Get(url)
 	if err != nil {
+		// Only a transport failure counts: an HTTP error means the network is
+		// fine and the answer simply is not there
+		r.noteDownloadFailure()
 		return nil, fmt.Errorf("failed to download: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	r.clearDownloadFailure()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to download: HTTP %d", resp.StatusCode)
@@ -150,6 +177,42 @@ func (r *Registry) downloadWithSizeLimit(url string, maxSize int64) ([]byte, err
 	}
 
 	return data, nil
+}
+
+// downloadFailurePath is the marker recording that the network was tried and
+// did not answer. Its modification time is the record.
+func (r *Registry) downloadFailurePath() string {
+	if r.cacheDir == "" {
+		return ""
+	}
+	return filepath.Join(r.cacheDir, "completion-download-failed")
+}
+
+// downloadRecentlyFailed reports whether the last attempt failed recently
+// enough that trying again would just make the user wait for nothing.
+func (r *Registry) downloadRecentlyFailed() bool {
+	path := r.downloadFailurePath()
+	if path == "" {
+		return false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) < DownloadRetryAfter
+}
+
+func (r *Registry) noteDownloadFailure() {
+	if path := r.downloadFailurePath(); path != "" {
+		_ = fsutil.AtomicWrite(path, nil, fsutil.StateFilePerm)
+	}
+}
+
+func (r *Registry) clearDownloadFailure() {
+	if path := r.downloadFailurePath(); path != "" {
+		_ = os.Remove(path)
+	}
 }
 
 // getRegistryPath returns the local cache path for the registry

--- a/internal/completion/registry_test.go
+++ b/internal/completion/registry_test.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1068,4 +1069,127 @@ func BenchmarkLoadRegistry(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _ = NewRegistry(tmpDir).Load()
 	}
+}
+
+// blackholeListener accepts connections and never answers them, which is what
+// a blocked proxy or a captive network looks like from here.
+func blackholeListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		var held []net.Conn
+		defer func() {
+			for _, c := range held {
+				_ = c.Close()
+			}
+		}()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			held = append(held, conn)
+		}
+	}()
+
+	return ln
+}
+
+// TestRegistry_DownloadIsBounded covers the wait a user sits through: the
+// registry is fetched during a completion, and http.DefaultClient - which is
+// what this used to use - has no timeout at all. A network that accepts the
+// connection and never answers hung the completion outright; one such attempt
+// was measured at 69 seconds.
+func TestRegistry_DownloadIsBounded(t *testing.T) {
+	ln := blackholeListener(t)
+
+	r := NewRegistry(t.TempDir())
+	r.baseURL = "http://" + ln.Addr().String()
+
+	start := time.Now()
+	_, err := r.Load()
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, DownloadTimeout*2, "the wait must be bounded by the timeout")
+	assert.GreaterOrEqual(t, elapsed, DownloadTimeout, "and it really did wait for it")
+}
+
+// TestRegistry_FailureIsRememberedAcrossProcesses is the other half: every
+// completion runs in its own process, so a failure noted only in memory would
+// be forgotten and the timeout paid again on every keypress.
+func TestRegistry_FailureIsRememberedAcrossProcesses(t *testing.T) {
+	ln := blackholeListener(t)
+	cacheDir := t.TempDir()
+
+	first := NewRegistry(cacheDir)
+	first.baseURL = "http://" + ln.Addr().String()
+	_, err := first.Load()
+	require.Error(t, err)
+
+	// A fresh Registry over the same cache dir, as the next completion would be
+	second := NewRegistry(cacheDir)
+	second.baseURL = "http://" + ln.Addr().String()
+
+	start := time.Now()
+	_, err = second.Load()
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, errDownloadPaused)
+	assert.Less(t, elapsed, 100*time.Millisecond, "a remembered failure must cost nothing")
+}
+
+func TestRegistry_SuccessClearsTheFailureMarker(t *testing.T) {
+	cacheDir := t.TempDir()
+	r := NewRegistry(cacheDir)
+
+	// An old failure, past the point where it still holds downloads back
+	r.noteDownloadFailure()
+	stale := time.Now().Add(-DownloadRetryAfter - time.Minute)
+	require.NoError(t, os.Chtimes(r.downloadFailurePath(), stale, stale))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("version: v1\ntools: {}\n"))
+	}))
+	defer server.Close()
+	r.baseURL = server.URL
+
+	_, err := r.Load()
+	require.NoError(t, err)
+
+	assert.NoFileExists(t, r.downloadFailurePath(), "a working network clears the note")
+}
+
+// TestRegistry_HTTPErrorIsNotANetworkFailure keeps the pause for the case it
+// is meant for: a 404 means the network works and the answer is not there, so
+// the next tool must still be looked up.
+func TestRegistry_HTTPErrorIsNotANetworkFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	r := NewRegistry(t.TempDir())
+	r.baseURL = server.URL
+
+	_, err := r.Load()
+	require.Error(t, err)
+	assert.False(t, r.downloadRecentlyFailed())
+}
+
+// TestRegistry_ExpiredMarkerIsRetried keeps a transient outage from disabling
+// downloads for good.
+func TestRegistry_ExpiredMarkerIsRetried(t *testing.T) {
+	cacheDir := t.TempDir()
+	r := NewRegistry(cacheDir)
+
+	r.noteDownloadFailure()
+	stale := time.Now().Add(-DownloadRetryAfter - time.Minute)
+	require.NoError(t, os.Chtimes(r.downloadFailurePath(), stale, stale))
+
+	assert.False(t, r.downloadRecentlyFailed(), "the network deserves another chance eventually")
 }

--- a/internal/completion/registry_test.go
+++ b/internal/completion/registry_test.go
@@ -1193,3 +1193,25 @@ func TestRegistry_ExpiredMarkerIsRetried(t *testing.T) {
 
 	assert.False(t, r.downloadRecentlyFailed(), "the network deserves another chance eventually")
 }
+
+// TestRegistry_NoCacheDirKeepsWorking covers the Registry built without a
+// cache directory: there is nowhere to note a failure, so downloads simply
+// carry on unguarded rather than breaking.
+func TestRegistry_NoCacheDirKeepsWorking(t *testing.T) {
+	r := NewRegistry("")
+
+	assert.Empty(t, r.downloadFailurePath())
+	assert.False(t, r.downloadRecentlyFailed(), "with nowhere to look, nothing is remembered")
+
+	// Neither of these has anywhere to write, and neither may panic
+	r.noteDownloadFailure()
+	r.clearDownloadFailure()
+	assert.False(t, r.downloadRecentlyFailed())
+}
+
+func TestRegistry_NoMarkerMeansNoRecentFailure(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+
+	// Nothing written yet: os.Stat fails and that is not a failure to honour
+	assert.False(t, r.downloadRecentlyFailed())
+}


### PR DESCRIPTION
Found while measuring where the completion time actually goes, following the
report of `tf <tab>` taking seconds.

## The wait nobody bounded

When no local completion script exists for a tool, dirvana fetches the registry
from GitHub — **during a completion**, with the user waiting at the prompt —
through `http.DefaultClient`, which has no timeout of any kind.

A first `kubectl <tab>` on a cold cache measured **69 seconds** here. A network
that accepts the connection and never answers — a captive portal, a proxy that
drops, a VPN coming up — hangs the completion outright.

## Why a timeout alone was not enough

Every completion runs in its own process, so nothing remembered the failure:
the timeout would have been paid again on **every keypress**. Verified against
a listener that accepts and never answers:

| attempt | before this PR | with timeout only | with this PR |
|---|---|---|---|
| 1st | hangs | 2.0s | 2.0s |
| 2nd | hangs | 2.0s | **0s** |
| 3rd | hangs | 2.0s | **0s** |

A failure is now noted in the cache directory and honoured for ten minutes,
after which the network gets another chance — a transient outage must not
disable downloads for good.

Only transport failures count. An HTTP error means the network works and the
answer is simply not there, so the next tool is still looked up (pinned by
`TestRegistry_HTTPErrorIsNotANetworkFailure`).

## Numbers

- first `kubectl <tab>`, cold cache, working network: **69s → 1.13s**
- blocked network: unbounded → 2s once, then free

## What this does *not* fix

`kubectl <tab>` still costs ~765ms once everything is cached, and that is
kubectl asking the cluster, not dirvana — its own logic measured at **2ms**
end to end (getwd, alias resolution, engine construction). Cutting that
would mean caching suggestions for stable levels, which is a separate and
more delicate change: it must never serve stale dynamic values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)